### PR TITLE
Add Colors for Hints

### DIFF
--- a/src/nord.yml
+++ b/src/nord.yml
@@ -56,3 +56,10 @@ colors:
     magenta: '#8c738c'
     cyan: '#6d96a5'
     white: '#aeb3bb'
+  hints:
+    start:
+      foreground: CellBackground
+      background: '#88c0d0'
+    end:
+      foreground: '#d8dee9'
+      background: '#434c5e'


### PR DESCRIPTION
Hints were added in version [0.8.0](https://github.com/alacritty/alacritty/releases/tag/v0.8.0) of Alacritty.

Left is default, right is this PR.
![hints](https://user-images.githubusercontent.com/3212673/119065911-9decfe00-b9ac-11eb-93d0-627d3394b3f9.png)
