### PR TITLE
fix: change colors.search.bar to colors.footer_bar

### DIFF
--- a/src/nord.yml
+++ b/src/nord.yml
@@ -26,9 +26,9 @@ colors:
     matches:
       foreground: CellBackground
       background: '#88c0d0'
-    bar:
-      background: '#434c5e'
-      foreground: '#d8dee9'
+  footer_bar:
+    background: '#434c5e'
+    foreground: '#d8dee9'
   normal:
     black: '#3b4252'
     red: '#bf616a'


### PR DESCRIPTION
Alacritty recently deprecated colors.search.bar in favour of colors.footer_bar in v0.11.0. This fixes the following deprecation warning.
<img width="681" alt="Screen Shot 2022-10-22 at 11 47 39 AM" src="https://user-images.githubusercontent.com/5464542/197348612-4b95b8ac-281b-425a-ad34-7a73d4a30f5b.png">


See CHANGELOG https://github.com/alacritty/alacritty/blob/master/CHANGELOG.md#0110