### PR TITLE
Footer bar update

### DIFF
--- a/src/nord.yml
+++ b/src/nord.yml
@@ -26,7 +26,7 @@ colors:
     matches:
       foreground: CellBackground
       background: '#88c0d0'
-    bar:
+  footer_bar:
       background: '#434c5e'
       foreground: '#d8dee9'
   normal:


### PR DESCRIPTION
'bar' has been deprecated; use `colors.footer_bar` instead.