### PR TITLE
Replaced bar with footer_bar

### DIFF
--- a/src/nord.yml
+++ b/src/nord.yml
@@ -26,9 +26,9 @@ colors:
     matches:
       foreground: CellBackground
       background: '#88c0d0'
-    bar:
-      background: '#434c5e'
-      foreground: '#d8dee9'
+  footer_bar:
+    background: '#434c5e'
+    foreground: '#d8dee9'
   normal:
     black: '#3b4252'
     red: '#bf616a'


### PR DESCRIPTION
colors.search.bar was deprecated and colors.footer_bar is it's replacement in version 0.11

Issue addressed here: https://github.com/alacritty/alacritty/blob/master/CHANGELOG.md
Extract from the document: Deprecated colors.search.bar, use colors.footer_bar instead